### PR TITLE
Feat: Add soft validation in updateAndValidateField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 - Improve documentation
 - Fix example project setup
+- Add optional soft validation when updating and validating an item
 
 ## v1.0.0
 - Initial release

--- a/lib/form/formx.dart
+++ b/lib/form/formx.dart
@@ -33,10 +33,18 @@ mixin FormX<T> {
     return validateForm(softValidation: true);
   }
 
-  /// Updates the value of the field and validates it, updating the computed variable [isFormValid]
+  /// Updates the value of the field and validates it, updating the computed variable [isFormValid].
+  /// When [softValidation] is true, it doesn't add errors messages to the fields, but updates the
+  /// computed variable [isFormValid] which can be used to show a submit button as enabled or disabled
   @action
-  Future<void> updateAndValidateField(dynamic newValue, T type) async {
-    inputMap[type] = await inputMap[type]!.updateValue(newValue).validateItem();
+  Future<void> updateAndValidateField(
+    dynamic newValue,
+    T type, {
+    bool softValidation = false,
+  }) async {
+    inputMap[type] = await inputMap[type]!
+        .updateValue(newValue)
+        .validateItem(softValidation: softValidation);
   }
 
   /// Updates the value of the field without validating it, this does not update the computed variable [isFormValid]

--- a/test/form/formx_test.dart
+++ b/test/form/formx_test.dart
@@ -193,6 +193,54 @@ void main() {
 
     group('and field is not valid', () {
       test(
+          'with soft validation then it should not update the error map with an '
+          'error but isValid should be updated', () {
+        fakeAsync((async) {
+          // setting up valid form
+          testClass.updateAndValidateField(
+            '12',
+            'a',
+          );
+          testClass.updateAndValidateField(
+            '123',
+            'b',
+          );
+          testClass.updateAndValidateField(
+            '1234',
+            'c',
+          );
+          async.elapse(const Duration(milliseconds: 200));
+
+          expect(testClass.inputMap['a']!.errorMessage, null);
+          // Form is valid
+          expect(testClass.isFormValid, true);
+
+          when(secondValidator.validate('123')).thenAnswer(
+            (_) async => const ValidatorResult(
+              isValid: false,
+              errorMessage: 'invalid string',
+            ),
+          );
+
+          // update with soft validation
+          testClass.updateAndValidateField(
+            '123',
+            'a',
+            softValidation: true,
+          );
+
+          async.elapse(const Duration(milliseconds: 200));
+          // error is not updated
+          expect(
+            testClass.inputMap['a']!.errorMessage,
+            null,
+          );
+          // form is now invalid because there is an error, even though it won't show in the UI
+          expect(testClass.isFormValid, false);
+        });
+      });
+
+      test(
           'with invalid string then it '
           'should update the error map with an error', () {
         fakeAsync((async) {


### PR DESCRIPTION
## Goal
- Add soft validation in updateAndValidateField in case it's needed to reset a form with validation after it's setup and not show errors in the UI

## Recommended steps
- [x] Add an entry on changelog such as: `- Fix required field validator via @yourusername`
- [x] Add unit tests
