### PR TITLE
Fix image paths in readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Changelog
+- Fix image paths in README
 
 ## v2.0.0
-- [Breaking change] Rename FormItem to FormXField 
+- [Breaking change] Rename FormItem to FormXField
 - [Breaking change] Expose the library file only
 - Improve documentation
 - Fix example project setup

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 [![pub package](https://img.shields.io/pub/v/flutter_formx?style=plastic&logo=flutter)](https://pub.dev/packages/flutter_formx)
 
-![Flutter FormX Logo](https://raw.githubusercontent.com/revelojobs/flutter_formx/main/docs/static/FormX_Symbol96.png)
+![Flutter FormX Logo](https://raw.githubusercontent.com/revelojobs/flutter_formx/main/doc/static/FormX_Symbol96.png)
 
 Flutter FormX is a package to make it easy to build, react to and validate forms using [MobX](https://pub.dev/packages/mobx).
 
 ## Features
 
-![Working form gif](https://raw.githubusercontent.com/revelojobs/flutter_formx/main/docs/static/FormX_example.gif)
+![Working form gif](https://raw.githubusercontent.com/revelojobs/flutter_formx/main/doc/static/FormX_example.gif)
 
 - Responsive state and form answer caching on current instance.
 - Form validation.


### PR DESCRIPTION
## Goal
Image paths broken because of folder renaming, this PR fixes the reference in README

## Recommended steps
- [x] Add an entry on changelog such as: `- Fix required field validator via @yourusername`
- [ ] Add unit tests
